### PR TITLE
develop

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,20 @@ pub trait Mkmk {
 }
 
 impl Mkmk for Path {
+    /// 親ディレクトリを再帰的に作成した後、空ファイルを作成する。
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// use std::path::Path;
+    ///
+    /// use mkmk::Mkmk;
+    ///
+    /// Path::new("aaa/bbb/ccc").mkmk().unwrap();
+    /// assert!(Path::new("aaa").is_dir());
+    /// assert!(Path::new("aaa/bbb").is_dir());
+    /// assert!(Path::new("aaa/bbb/ccc").is_file());
+    /// ```
     fn mkmk(&self) -> Result<()> {
         if let Some(parent) = self.parent() {
             if let Err(e) = fs::create_dir_all(parent) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,23 @@
 use std::fs;
 use std::fs::File;
 use std::path::Path;
+use std::path::PathBuf;
 
 use anyhow::bail;
 use anyhow::Result;
+
+pub fn run(paths: Vec<PathBuf>) -> i32 {
+    let mut exit_code = 0;
+
+    for path in paths {
+        if let Err(e) = path.mkmk() {
+            eprintln!("Error: {}", e);
+            exit_code = 1;
+        }
+    }
+
+    exit_code
+}
 
 pub trait Mkmk {
     fn mkmk(&self) -> Result<()>;

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,8 +2,6 @@ use std::{path::PathBuf, process};
 
 use clap::Parser;
 
-use mkmk::Mkmk;
-
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None, arg_required_else_help = true)]
 struct Args {
@@ -13,14 +11,8 @@ struct Args {
 
 fn main() {
     let args = Args::parse();
-    let mut exit_code = 0;
 
-    for path in args.paths {
-        if let Err(e) = path.mkmk() {
-            eprintln!("Error: {}", e);
-            exit_code = 1;
-        }
-    }
+    let exit_code = mkmk::run(args.paths);
 
     process::exit(exit_code);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,8 @@ use std::{path::PathBuf, process};
 
 use clap::Parser;
 
+use mkmk::Mkmk;
+
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None, arg_required_else_help = true)]
 struct Args {
@@ -14,7 +16,7 @@ fn main() {
     let mut exit_code = 0;
 
     for path in args.paths {
-        if let Err(e) = mkmk::run(&path) {
+        if let Err(e) = path.mkmk() {
             eprintln!("Error: {}", e);
             exit_code = 1;
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,3 @@
-extern crate mkmk;
-
 use std::{path::PathBuf, process};
 
 use clap::Parser;


### PR DESCRIPTION
- Remove "extern crate mkmk;"
- Mkmk トレイトで Path を拡張するように変更
- run 関数に処理を抽出
- mkmk() に Doc-test を追加。ファイルが実際に作成されるので ignore
