### PR TITLE
build(deps): add npm updates to dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,3 +14,8 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
This pull request includes a small change to the `.github/dependabot.yml` file. The change adds a new configuration for the `npm` package-ecosystem with a monthly update schedule.

Changes in `.github/dependabot.yml`:

* Added a new `package-ecosystem: "npm"` configuration with a monthly update schedule.